### PR TITLE
iPad Pro and other needed sizes, added overwrite and Contents.json options

### DIFF
--- a/Script-Fu/export_iOS_icons_of_image.scm
+++ b/Script-Fu/export_iOS_icons_of_image.scm
@@ -153,24 +153,50 @@
 (script-fu-menu-register "export-image-as-ios-images" "<Image>/File/iOS Export/Image as")
 
 ; ------------------------------------------------------------------------------
-(define (export-image-as-app-icons-for-devices inImage inDrawable inPath iniPadIcons iniPhoneIcons)
+(define (export-image-as-app-icons-for-devices inImage inDrawable inPath iniPadIcons iniPhoneIcons iniAppleWatch)
     
-    (if (or (= 1 iniPadIcons) (= 1 iniPhoneIcons))
+    (if (or (= 1 iniPadIcons) (= 1 iniPhoneIcons) (= 1 iniAppleWatch))
         (begin
-            (export-as-ios-image inImage inDrawable inPath "iTunesArtwork@2x" 1024 1024)
-            (export-as-ios-image inImage inDrawable inPath "iTunesArtwork" 512 512)
-            (export-as-ios-image inImage inDrawable inPath "Icon-Small@2x.png" 58 58)
-            (export-as-ios-image inImage inDrawable inPath "Icon-Small.png" 29 29)))
+			(export-as-ios-image inImage inDrawable inPath "iTunesArtwork@3x.png" 1536 1536)
+            (export-as-ios-image inImage inDrawable inPath "iTunesArtwork@2x.png" 1024 1024)
+            (export-as-ios-image inImage inDrawable inPath "iTunesArtwork.png" 512 512)
+            (export-as-ios-image inImage inDrawable inPath "Icon-Spotlight@3x.png" 120 120)
+            (export-as-ios-image inImage inDrawable inPath "Icon-Spotlight@2x.png" 80 80)
+            ;(export-as-ios-image inImage inDrawable inPath "Icon-Spotlight.png" 40 40)
+            (export-as-ios-image inImage inDrawable inPath "Icon-Settings@3x.png" 87 87)
+            (export-as-ios-image inImage inDrawable inPath "Icon-Settings@2x.png" 58 58)
+            ;(export-as-ios-image inImage inDrawable inPath "Icon-Settings.png" 29 29)
+            ))
     (if (= 1 iniPadIcons)
         (begin
-            (export-as-ios-image inImage inDrawable inPath "Icon-72@2x.png" 144 144)
-            (export-as-ios-image inImage inDrawable inPath "Icon-72.png" 72 72)
-            (export-as-ios-image inImage inDrawable inPath "Icon-Small-50@2x.png" 100 100)
-            (export-as-ios-image inImage inDrawable inPath "Icon-Small-50.png" 50 50)))
+            (export-as-ios-image inImage inDrawable inPath "Icon-iPad@3x.png" 228 228)
+            (export-as-ios-image inImage inDrawable inPath "Icon-iPad@2x.png" 152 152)
+            (export-as-ios-image inImage inDrawable inPath "Icon-iPad.png" 76 76)
+            ))
     (if (= 1 iniPhoneIcons)
         (begin
-            (export-as-ios-image inImage inDrawable inPath "Icon@2x.png" 114 114)
-            (export-as-ios-image inImage inDrawable inPath "Icon.png" 57 57))))
+            (export-as-ios-image inImage inDrawable inPath "Icon-iPhone@3x.png" 180 180)
+            (export-as-ios-image inImage inDrawable inPath "Icon-iPhone@2x.png" 120 120)
+            ;(export-as-ios-image inImage inDrawable inPath "Icon-iPhone.png" 60 60)
+            ))
+    (if (= 1 iniAppleWatch)
+        (begin
+            (export-as-ios-image inImage inDrawable inPath "Icon-Watch-42mm-HomeScreen-SL@2x.png" 196 196)
+            ;(export-as-ios-image inImage inDrawable inPath "Icon-Watch-42mm-HomeScreen-SL.png" 98 98)
+            (export-as-ios-image inImage inDrawable inPath "Icon-Watch-38mm-HomeScreen-SL@2x.png" 172 172)
+            ;(export-as-ios-image inImage inDrawable inPath "Icon-Watch-38mm-HomeScreen-SL.png" 86 86)
+            (export-as-ios-image inImage inDrawable inPath "Icon-Watch-42mm-HomeScreen-LL@2x.png" 88 88)
+            ;(export-as-ios-image inImage inDrawable inPath "Icon-Watch-42mm-HomeScreen-LL.png" 44 44)
+            (export-as-ios-image inImage inDrawable inPath "Icon-Watch-38mm-HomeScreen-LL@2x.png" 80 80)
+            ;(export-as-ios-image inImage inDrawable inPath "Icon-Watch-38mm-HomeScreen-LL.png" 40 40)
+            (export-as-ios-image inImage inDrawable inPath "Icon-Watch-Settings@3x.png" 87 87)
+            (export-as-ios-image inImage inDrawable inPath "Icon-Watch-Settings@2x.png" 58 58)
+            ;(export-as-ios-image inImage inDrawable inPath "Icon-Watch-Settings.png" 29 29)
+            (export-as-ios-image inImage inDrawable inPath "Icon-Watch-42mm-Notification@2x.png" 55 55)
+            ;(export-as-ios-image inImage inDrawable inPath "Icon-Watch-42mm-Notification.png" 27.5 27.5)
+            (export-as-ios-image inImage inDrawable inPath "Icon-Watch-38mm-Notification@2x.png" 48 48)
+            ;(export-as-ios-image inImage inDrawable inPath "Icon-Watch-38mm-Notification.png" 24 24)
+            )))
 
 ; - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 (script-fu-register
@@ -192,6 +218,7 @@
     SF-DIRNAME  "Path"                              "/tmp"
     SF-TOGGLE   "Create iPad icons"                 1
     SF-TOGGLE   "Create iPhone/iPod touch icons"    1
+    SF-TOGGLE	"Create Apple Watch Icons"			1
 )
 
 (script-fu-menu-register "export-image-as-app-icons-for-devices" "<Image>/File/iOS Export/Image as")

--- a/Script-Fu/export_iOS_icons_of_image.scm
+++ b/Script-Fu/export_iOS_icons_of_image.scm
@@ -2,14 +2,19 @@
 ; Copyright (c) 2013 Michael Morris
 ; This software is released under MIT Open Source License
 ; ==============================================================================
-
+; Enhancements:
+;
+; Watch support added by Salvador Guerrero - May 3, 2015 (https://github.com/m2orris/GIMP-scripts/pull/8)
+;
+; iPad Pro support, Overwrite logic, Asset Catalog Contents.json support added by Andy Johns - March 4, 2016
+;
 ; ------------------------------------------------------------------------------
-(define (export-as-ios-image inImage inDrawable inPath inFilename inWidth inHeight)
+(define (export-as-ios-image inImage inDrawable inPath inFilename inWidth inHeight  inOverwrite)
     (let* (
         (thePathAndFilename (string-append inPath DIR-SEPARATOR inFilename)))
         
         ; Check to make sure thePathAndFilename does not exist
-        (if (file-exists? thePathAndFilename)
+        (if (and (= 0 inOverwrite) (file-exists? thePathAndFilename))
         
             ; The file exists, then display message and exit
             (gimp-message (string-append "The file:[" thePathAndFilename "] exists, skipping."))
@@ -153,50 +158,82 @@
 (script-fu-menu-register "export-image-as-ios-images" "<Image>/File/iOS Export/Image as")
 
 ; ------------------------------------------------------------------------------
-(define (export-image-as-app-icons-for-devices inImage inDrawable inPath iniPadIcons iniPhoneIcons iniAppleWatch)
+(define (export-image-as-app-icons-for-devices inImage inDrawable inPath iniPadIcons iniPhoneIcons iniAppleWatch iniITunesArtwork inOverwrite inCreateJSON)
     
-    (if (or (= 1 iniPadIcons) (= 1 iniPhoneIcons) (= 1 iniAppleWatch))
-        (begin
-			(export-as-ios-image inImage inDrawable inPath "iTunesArtwork@3x.png" 1536 1536)
-            (export-as-ios-image inImage inDrawable inPath "iTunesArtwork@2x.png" 1024 1024)
-            (export-as-ios-image inImage inDrawable inPath "iTunesArtwork.png" 512 512)
-            (export-as-ios-image inImage inDrawable inPath "Icon-Spotlight@3x.png" 120 120)
-            (export-as-ios-image inImage inDrawable inPath "Icon-Spotlight@2x.png" 80 80)
-            ;(export-as-ios-image inImage inDrawable inPath "Icon-Spotlight.png" 40 40)
-            (export-as-ios-image inImage inDrawable inPath "Icon-Settings@3x.png" 87 87)
-            (export-as-ios-image inImage inDrawable inPath "Icon-Settings@2x.png" 58 58)
-            ;(export-as-ios-image inImage inDrawable inPath "Icon-Settings.png" 29 29)
-            ))
     (if (= 1 iniPadIcons)
         (begin
-            (export-as-ios-image inImage inDrawable inPath "Icon-iPad@3x.png" 228 228)
-            (export-as-ios-image inImage inDrawable inPath "Icon-iPad@2x.png" 152 152)
-            (export-as-ios-image inImage inDrawable inPath "Icon-iPad.png" 76 76)
+            (export-as-ios-image inImage inDrawable inPath "Icon-iPadPro@2x.png" 167 167 inOverwrite)
+            (export-as-ios-image inImage inDrawable inPath "Icon-iPad@2x.png" 152 152 inOverwrite)
+            (export-as-ios-image inImage inDrawable inPath "Icon-iPad.png" 76 76 inOverwrite)
+            (export-as-ios-image inImage inDrawable inPath "Icon-iPad-Settings@2x.png" 58 58 inOverwrite)
+            (export-as-ios-image inImage inDrawable inPath "Icon-iPad-Settings.png" 29 29 inOverwrite)
+            (export-as-ios-image inImage inDrawable inPath "Icon-iPad-Spotlight@2x.png" 80 80 inOverwrite)
+            (export-as-ios-image inImage inDrawable inPath "Icon-iPad-Spotlight.png" 40 40 inOverwrite)
             ))
     (if (= 1 iniPhoneIcons)
         (begin
-            (export-as-ios-image inImage inDrawable inPath "Icon-iPhone@3x.png" 180 180)
-            (export-as-ios-image inImage inDrawable inPath "Icon-iPhone@2x.png" 120 120)
-            ;(export-as-ios-image inImage inDrawable inPath "Icon-iPhone.png" 60 60)
+            (export-as-ios-image inImage inDrawable inPath "Icon-iPhone@3x.png" 180 180 inOverwrite)
+            (export-as-ios-image inImage inDrawable inPath "Icon-iPhone@2x.png" 120 120 inOverwrite)
+            (export-as-ios-image inImage inDrawable inPath "Icon-iPhone-Settings@3x.png" 87 87 inOverwrite)
+            (export-as-ios-image inImage inDrawable inPath "Icon-iPhone-Settings@2x.png" 58 58 inOverwrite)
+            (export-as-ios-image inImage inDrawable inPath "Icon-iPhone-Settings.png" 29 29 inOverwrite)
+            (export-as-ios-image inImage inDrawable inPath "Icon-iPhone-Spotlight@3x.png" 120 120 inOverwrite)
+            (export-as-ios-image inImage inDrawable inPath "Icon-iPhone-Spotlight@2x.png" 80 80 inOverwrite)
             ))
     (if (= 1 iniAppleWatch)
         (begin
-            (export-as-ios-image inImage inDrawable inPath "Icon-Watch-42mm-HomeScreen-SL@2x.png" 196 196)
-            ;(export-as-ios-image inImage inDrawable inPath "Icon-Watch-42mm-HomeScreen-SL.png" 98 98)
-            (export-as-ios-image inImage inDrawable inPath "Icon-Watch-38mm-HomeScreen-SL@2x.png" 172 172)
-            ;(export-as-ios-image inImage inDrawable inPath "Icon-Watch-38mm-HomeScreen-SL.png" 86 86)
-            (export-as-ios-image inImage inDrawable inPath "Icon-Watch-42mm-HomeScreen-LL@2x.png" 88 88)
-            ;(export-as-ios-image inImage inDrawable inPath "Icon-Watch-42mm-HomeScreen-LL.png" 44 44)
-            (export-as-ios-image inImage inDrawable inPath "Icon-Watch-38mm-HomeScreen-LL@2x.png" 80 80)
-            ;(export-as-ios-image inImage inDrawable inPath "Icon-Watch-38mm-HomeScreen-LL.png" 40 40)
-            (export-as-ios-image inImage inDrawable inPath "Icon-Watch-Settings@3x.png" 87 87)
-            (export-as-ios-image inImage inDrawable inPath "Icon-Watch-Settings@2x.png" 58 58)
-            ;(export-as-ios-image inImage inDrawable inPath "Icon-Watch-Settings.png" 29 29)
-            (export-as-ios-image inImage inDrawable inPath "Icon-Watch-42mm-Notification@2x.png" 55 55)
-            ;(export-as-ios-image inImage inDrawable inPath "Icon-Watch-42mm-Notification.png" 27.5 27.5)
-            (export-as-ios-image inImage inDrawable inPath "Icon-Watch-38mm-Notification@2x.png" 48 48)
-            ;(export-as-ios-image inImage inDrawable inPath "Icon-Watch-38mm-Notification.png" 24 24)
-            )))
+            (export-as-ios-image inImage inDrawable inPath "Icon-Watch-42mm-HomeScreen-SL@2x.png" 196 196 inOverwrite)
+            (export-as-ios-image inImage inDrawable inPath "Icon-Watch-38mm-HomeScreen-SL@2x.png" 172 172 inOverwrite)
+            (export-as-ios-image inImage inDrawable inPath "Icon-Watch-42mm-HomeScreen-LL@2x.png" 88 88 inOverwrite)
+            (export-as-ios-image inImage inDrawable inPath "Icon-Watch-38mm-HomeScreen-LL@2x.png" 80 80 inOverwrite)
+            (export-as-ios-image inImage inDrawable inPath "Icon-Watch-Settings@3x.png" 87 87 inOverwrite)
+            (export-as-ios-image inImage inDrawable inPath "Icon-Watch-Settings@2x.png" 58 58 inOverwrite)
+            (export-as-ios-image inImage inDrawable inPath "Icon-Watch-42mm-Notification@2x.png" 55 55 inOverwrite)
+            (export-as-ios-image inImage inDrawable inPath "Icon-Watch-38mm-Notification@2x.png" 48 48 inOverwrite)
+            ))
+    (if (= 1 iniITunesArtwork)
+        (begin
+			(export-as-ios-image inImage inDrawable inPath "iTunesArtwork@3x.png" 1536 1536 inOverwrite)
+            (export-as-ios-image inImage inDrawable inPath "iTunesArtwork@2x.png" 1024 1024 inOverwrite)
+            (export-as-ios-image inImage inDrawable inPath "iTunesArtwork.png" 512 512 inOverwrite)
+            ))
+    (if (= 1 inCreateJSON)
+		(begin
+			(let* (
+			(outport (open-output-file (string-append inPath DIR-SEPARATOR "Contents.json"))))
+			
+			(display "{\n  \"images\" : [\n" outport)
+			(display "    {\n      \"size\" : \"29x29\",\n      \"idiom\" : \"iphone\",\n      \"filename\" : \"Icon-iPhone-Settings.png\",\n      \"scale\" : \"1x\"\n    },\n" outport)
+			(display "    {\n      \"size\" : \"29x29\",\n      \"idiom\" : \"iphone\",\n      \"filename\" : \"Icon-iPhone-Settings@2x.png\",\n      \"scale\" : \"2x\"\n    },\n" outport)
+			(display "    {\n      \"size\" : \"29x29\",\n      \"idiom\" : \"iphone\",\n      \"filename\" : \"Icon-iPhone-Settings@3x.png\",\n      \"scale\" : \"3x\"\n    },\n" outport)
+			(display "    {\n      \"size\" : \"40x40\",\n      \"idiom\" : \"iphone\",\n      \"filename\" : \"Icon-iPhone-Spotlight@2x.png\",\n      \"scale\" : \"2x\"\n    },\n" outport)
+			(display "    {\n      \"size\" : \"40x40\",\n      \"idiom\" : \"iphone\",\n      \"filename\" : \"Icon-iPhone-Spotlight@3x.png\",\n      \"scale\" : \"3x\"\n    },\n" outport)
+			(display "    {\n      \"idiom\" : \"iphone\",\n      \"size\" : \"57x57\",\n      \"scale\" : \"1x\"\n    },\n" outport)
+			(display "    {\n      \"idiom\" : \"iphone\",\n      \"size\" : \"57x57\",\n      \"scale\" : \"2x\"\n    },\n" outport)
+			(display "    {\n      \"size\" : \"60x60\",\n      \"idiom\" : \"iphone\",\n      \"filename\" : \"Icon-iPhone@2x.png\",\n      \"scale\" : \"2x\"\n    },\n" outport)
+			(display "    {\n      \"size\" : \"60x60\",\n      \"idiom\" : \"iphone\",\n      \"filename\" : \"Icon-iPhone@3x.png\",\n      \"scale\" : \"3x\"\n    },\n" outport)
+			(display "    {\n      \"size\" : \"29x29\",\n      \"idiom\" : \"ipad\",\n      \"filename\" : \"Icon-iPad-Settings.png\",\n      \"scale\" : \"1x\"\n    },\n" outport)
+			(display "    {\n      \"size\" : \"29x29\",\n      \"idiom\" : \"ipad\",\n      \"filename\" : \"Icon-iPad-Settings@2x.png\",\n      \"scale\" : \"2x\"\n    },\n" outport)
+			(display "    {\n      \"size\" : \"40x40\",\n      \"idiom\" : \"ipad\",\n      \"filename\" : \"Icon-iPad-Spotlight.png\",\n      \"scale\" : \"1x\"\n    },\n" outport)
+			(display "    {\n      \"size\" : \"40x40\",\n      \"idiom\" : \"ipad\",\n      \"filename\" : \"Icon-iPad-Spotlight@2x.png\",\n      \"scale\" : \"2x\"\n    },\n" outport)
+			(display "    {\n      \"idiom\" : \"ipad\",\n      \"size\" : \"50x50\",\n      \"scale\" : \"1x\"\n    },\n" outport)
+			(display "    {\n      \"idiom\" : \"ipad\",\n      \"size\" : \"50x50\",\n      \"scale\" : \"2x\"\n    },\n" outport)
+			(display "    {\n      \"idiom\" : \"ipad\",\n      \"size\" : \"72x72\",\n      \"scale\" : \"1x\"\n    },\n" outport)
+			(display "    {\n      \"idiom\" : \"ipad\",\n      \"size\" : \"72x72\",\n      \"scale\" : \"2x\"\n    },\n" outport)
+			(display "    {\n      \"size\" : \"76x76\",\n      \"idiom\" : \"ipad\",\n      \"filename\" : \"Icon-iPad.png\",\n      \"scale\" : \"1x\"\n    },\n" outport)
+			(display "    {\n      \"size\" : \"76x76\",\n      \"idiom\" : \"ipad\",\n      \"filename\" : \"Icon-iPad@2x.png\",\n      \"scale\" : \"2x\"\n    },\n" outport)
+			(display "    {\n      \"size\" : \"83.5x83.5\",\n      \"idiom\" : \"ipad\",\n      \"filename\" : \"Icon-iPadPro@2x.png\",\n      \"scale\" : \"2x\"\n    },\n" outport)
+			(display "    {\n      \"size\" : \"24x24\",\n      \"idiom\" : \"watch\",\n      \"filename\" : \"Icon-Watch-38mm-Notification@2x.png\",\n      \"scale\" : \"2x\",\n      \"role\" : \"notificationCenter\",\n      \"subtype\" : \"38mm\"\n    },\n" outport)
+			(display "    {\n      \"size\" : \"27.5x27.5\",\n      \"idiom\" : \"watch\",\n      \"filename\" : \"Icon-Watch-42mm-Notification@2x.png\",\n      \"scale\" : \"2x\",\n      \"role\" : \"notificationCenter\",\n      \"subtype\" : \"42mm\"\n    },\n" outport)
+			(display "    {\n      \"size\" : \"29x29\",\n      \"idiom\" : \"watch\",\n      \"filename\" : \"Icon-Watch-Settings@2x.png\",\n      \"role\" : \"companionSettings\",\n      \"scale\" : \"2x\"\n    },\n" outport)
+			(display "    {\n      \"size\" : \"29x29\",\n      \"idiom\" : \"watch\",\n      \"filename\" : \"Icon-Watch-Settings@3x.png\",\n      \"role\" : \"companionSettings\",\n      \"scale\" : \"3x\"\n    },\n" outport)
+			(display "    {\n      \"size\" : \"40x40\",\n      \"idiom\" : \"watch\",\n      \"filename\" : \"Icon-Watch-38mm-HomeScreen-LL@2x.png\",\n      \"scale\" : \"2x\",\n      \"role\" : \"appLauncher\",\n      \"subtype\" : \"38mm\"\n    },\n" outport)
+			(display "    {\n      \"size\" : \"44x44\",\n      \"idiom\" : \"watch\",\n      \"filename\" : \"Icon-Watch-42mm-HomeScreen-LL@2x.png\",\n      \"scale\" : \"2x\",\n      \"role\" : \"longLook\",\n      \"subtype\" : \"42mm\"\n    },\n" outport)
+			(display "    {\n      \"size\" : \"86x86\",\n      \"idiom\" : \"watch\",\n      \"filename\" : \"Icon-Watch-38mm-HomeScreen-SL@2x.png\",\n      \"scale\" : \"2x\",\n      \"role\" : \"quickLook\",\n      \"subtype\" : \"38mm\"\n    },\n" outport)
+			(display "    {\n      \"size\" : \"98x98\",\n      \"idiom\" : \"watch\",\n      \"filename\" : \"Icon-Watch-42mm-HomeScreen-SL@2x.png\",\n      \"scale\" : \"2x\",\n      \"role\" : \"quickLook\",\n      \"subtype\" : \"42mm\"\n    }\n" outport)
+			(display "  ],\n  \"info\" : {\n    \"version\" : 1,\n    \"author\" : \"xcode\"\n  }\n}" outport)
+			(close-output-port outport)
+			))))
 
 ; - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 (script-fu-register
@@ -213,12 +250,15 @@
     This software is released under MIT Open Source License"        ;copyright notice
     "July 17, 2013"                                                 ;date created
     "*"                                                             ;image type that the script works on
-    SF-IMAGE    "Image"                             0
-    SF-DRAWABLE "Drawable"                          0
-    SF-DIRNAME  "Path"                              "/tmp"
-    SF-TOGGLE   "Create iPad icons"                 1
-    SF-TOGGLE   "Create iPhone/iPod touch icons"    1
-    SF-TOGGLE	"Create Apple Watch Icons"			1
+    SF-IMAGE    "Image"                             	0
+    SF-DRAWABLE "Drawable"                          	0
+    SF-DIRNAME  "Path"                              	"/tmp"
+    SF-TOGGLE   "Create iPad icons"                 	1
+    SF-TOGGLE   "Create iPhone/iPod touch icons"    	1
+    SF-TOGGLE	"Create Apple Watch Icons"				1
+    SF-TOGGLE	"Create iTunes Artwork"	  				0
+    SF-TOGGLE	"Overwrite existing files?"	  			0
+    SF-TOGGLE   "Create asset catalog Content.json?" 	0
 )
 
-(script-fu-menu-register "export-image-as-app-icons-for-devices" "<Image>/File/iOS Export/Image as")
+(script-fu-menu-register "export-image-as-app-icons-for-devices" "<Image>/File/iOS Export/")


### PR DESCRIPTION
Included ObjSal's Apple Watch Suport and added:
- Added support for iPad Pro
- Changed to write individual images for all icons needed (as of Xcode 7.2) for iOS 7+
- Removed commented out icons
- Added option to allow overwriting of image files
- Added option to output Xcode asset catalog Contents.json file
- Moved "App Icons for Device(s) ..." menu item to same level as "Image As" and "Retina Resolution Image as"
